### PR TITLE
MMS: Fix already redirected issue

### DIFF
--- a/src/controllers/PartialUserFormController.php
+++ b/src/controllers/PartialUserFormController.php
@@ -56,7 +56,7 @@ class PartialUserFormController extends UserDefinedFormController
 
         // Check if form is locked
         if (static::isLockedOut()) {
-            $this->redirect($page->link('overview'));
+            return $this->redirect($page->link('overview'));
         } else {
             // Claim the form session
             PartialSubmissionController::reloadSession($request->getSession(), $partial->ID);


### PR DESCRIPTION
When a user navigates to a locked form with password, the user should be redirected to overview page and not continue with verify redirection.

Error: `Already directed to http://mbie.test/science-and-technology/space/space-related-opportunities-in-new-zealand/application-for-payload-permit-app001/overview; now trying to direct to /science-and-technology/space/space-related-opportunities-in-new-zealand/application-for-payload-permit-app001/verify`
